### PR TITLE
Corrección en Doughnut Charts

### DIFF
--- a/app/src/main/java/cl/niclabs/adkintunmobile/views/connectiontype/DailyConnectionTypeInformation.java
+++ b/app/src/main/java/cl/niclabs/adkintunmobile/views/connectiontype/DailyConnectionTypeInformation.java
@@ -39,6 +39,8 @@ public abstract class DailyConnectionTypeInformation extends StatisticInformatio
 
     public abstract int getPrimaryType();
 
+    protected abstract DailyConnectionTypeSummary getLastDaySummary(long initialTime);
+
     /**
      * Get all ConnectionTypeSample's of the day represented with "initialTime" parameter.
      * Then, save ColorsArray and ValuesArray generated to build the DoughnutChart. Also save
@@ -82,11 +84,11 @@ public abstract class DailyConnectionTypeInformation extends StatisticInformatio
 
         //Si primer reporte del día no parte de las 0 AM, completar con último del día anterior
         if (lastTime >= initialTime) {
-            DailyConnectionTypeSummary yesterdaySummary = getSummary(initialTime - period);
-            Iterator<? extends ConnectionTypeSample> yesterdaySamples = yesterdaySummary.getSamples();
-            if (yesterdaySamples.hasNext()){
-                while (yesterdaySamples.hasNext()) {
-                    sample = yesterdaySamples.next();
+            DailyConnectionTypeSummary lastDaySummary = getLastDaySummary(initialTime);
+            Iterator<? extends ConnectionTypeSample> lastDaySamples = lastDaySummary.getSamples();
+            if (lastDaySamples.hasNext()){
+                while (lastDaySamples.hasNext()) {
+                    sample = lastDaySamples.next();
                 }
                 lastColor = connectionTypeColors.getColor(sample.getType(), 0);
                 colors.add( lastColor );

--- a/app/src/main/java/cl/niclabs/adkintunmobile/views/connectiontype/connectionmode/DailyConnectionModeInformation.java
+++ b/app/src/main/java/cl/niclabs/adkintunmobile/views/connectiontype/connectionmode/DailyConnectionModeInformation.java
@@ -3,6 +3,8 @@ package cl.niclabs.adkintunmobile.views.connectiontype.connectionmode;
 import android.content.Context;
 import android.content.res.TypedArray;
 
+import java.util.Iterator;
+
 import cl.niclabs.adkintunmobile.R;
 import cl.niclabs.adkintunmobile.data.persistent.visualization.ConnectionModeSample;
 import cl.niclabs.adkintunmobile.data.persistent.visualization.DailyConnectionModeSummary;
@@ -40,5 +42,21 @@ public class DailyConnectionModeInformation extends DailyConnectionTypeInformati
         if (timeByType[ConnectionModeSample.WIFI] > timeByType[primaryType])
             primaryType = ConnectionModeSample.WIFI;
         return  primaryType;
+    }
+
+    @Override
+    protected DailyConnectionTypeSummary getLastDaySummary(long initialTime) {
+        String[] whereArgs = new String[1];
+        whereArgs[0] = Long.toString(initialTime);
+        Iterator<DailyConnectionModeSummary> pastDaysSummaries = DailyConnectionModeSummary.find(DailyConnectionModeSummary.class, "date < ?", whereArgs, "date DESC");
+        if (pastDaysSummaries.hasNext()){
+            while (pastDaysSummaries.hasNext()){
+                DailyConnectionModeSummary pastDaySummary = pastDaysSummaries.next();
+                if (pastDaySummary.getSamples().hasNext()){
+                    return pastDaySummary;
+                }
+            }
+        }
+        return getSummary(initialTime - period);
     }
 }

--- a/app/src/main/java/cl/niclabs/adkintunmobile/views/connectiontype/networktype/DailyNetworkTypeInformation.java
+++ b/app/src/main/java/cl/niclabs/adkintunmobile/views/connectiontype/networktype/DailyNetworkTypeInformation.java
@@ -3,6 +3,8 @@ package cl.niclabs.adkintunmobile.views.connectiontype.networktype;
 import android.content.Context;
 import android.content.res.TypedArray;
 
+import java.util.Iterator;
+
 import cl.niclabs.adkintunmobile.R;
 import cl.niclabs.adkintunmobile.data.persistent.visualization.DailyConnectionTypeSummary;
 import cl.niclabs.adkintunmobile.data.persistent.visualization.DailyNetworkTypeSummary;
@@ -48,5 +50,21 @@ public class DailyNetworkTypeInformation extends DailyConnectionTypeInformation{
         if (timeByType[NetworkTypeSample.TYPE_4G] > timeByType[primaryType])
         primaryType = NetworkTypeSample.TYPE_4G;
         return  primaryType;
+    }
+
+    @Override
+    protected DailyConnectionTypeSummary getLastDaySummary(long initialTime) {
+        String[] whereArgs = new String[1];
+        whereArgs[0] = Long.toString(initialTime);
+        Iterator<DailyNetworkTypeSummary> pastDaysSummaries = DailyNetworkTypeSummary.find(DailyNetworkTypeSummary.class, "date < ?", whereArgs, "date DESC");
+        if (pastDaysSummaries.hasNext()){
+            while (pastDaysSummaries.hasNext()){
+                DailyNetworkTypeSummary pastDaySummary = pastDaysSummaries.next();
+                if (pastDaySummary.getSamples().hasNext()){
+                    return pastDaySummary;
+                }
+            }
+        }
+        return getSummary(initialTime - period);
     }
 }


### PR DESCRIPTION
Para completar la información del día se busca el último registro guardado, considerando todos los días anteriores a la fecha escogida y no solamente  el día inmediatamente anterior. Con esto,  se evitan posibles días visualizados "sin información" al no haber registros para dicho día ni para el día anterior.
