### PR TITLE
Fix telephony events

### DIFF
--- a/app/src/main/java/cl/niclabs/adkintunmobile/data/Report.java
+++ b/app/src/main/java/cl/niclabs/adkintunmobile/data/Report.java
@@ -68,6 +68,10 @@ public class Report {
         setUpReport();
     }
 
+    /**
+     * Prepares the report to be sent.
+     * Saves the last GsmObservation to avoid saving incremental records and remove events with the same timestamp.
+     */
     private void setUpReport() {
         int gsmRecordsSize = gsmRecords.size();
         if (gsmRecordsSize > 0) {

--- a/app/src/main/java/cl/niclabs/adkintunmobile/data/persistent/GsmObservationWrapper.java
+++ b/app/src/main/java/cl/niclabs/adkintunmobile/data/persistent/GsmObservationWrapper.java
@@ -4,6 +4,8 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
 
+import cl.niclabs.android.data.DoNotSerialize;
+
 public class GsmObservationWrapper extends TelephonyObservationWrapper{
 
     @SerializedName("gsm_cid")
@@ -17,6 +19,7 @@ public class GsmObservationWrapper extends TelephonyObservationWrapper{
     public List<NeighborAntennaWrapper> neighborList;
 
     @SerializedName("signal_ber")
+    @DoNotSerialize
     public SampleWrapper signalBer;
 
     public GsmObservationWrapper() {

--- a/app/src/main/java/cl/niclabs/adkintunmobile/data/persistent/GsmObservationWrapper.java
+++ b/app/src/main/java/cl/niclabs/adkintunmobile/data/persistent/GsmObservationWrapper.java
@@ -29,4 +29,10 @@ public class GsmObservationWrapper extends TelephonyObservationWrapper{
             this.signalBer.save();
         super.save();
     }
+
+    public boolean sameAntenna(GsmObservationWrapper sample){
+        return this.gsmCid == sample.gsmCid
+                && this.gsmLac == sample.gsmLac
+                && this.gsmPsc == sample.gsmPsc;
+    }
 }

--- a/app/src/main/java/cl/niclabs/adkintunmobile/services/monitors/TelephonyMonitor.java
+++ b/app/src/main/java/cl/niclabs/adkintunmobile/services/monitors/TelephonyMonitor.java
@@ -8,8 +8,6 @@ import android.util.Log;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import java.util.Iterator;
-
 import cl.niclabs.adkintunmobile.data.persistent.CdmaObservationWrapper;
 import cl.niclabs.adkintunmobile.data.persistent.GsmObservationWrapper;
 import cl.niclabs.adkintunmobile.data.persistent.SampleWrapper;
@@ -100,12 +98,6 @@ public class TelephonyMonitor extends Service implements TelephonyListener {
             else {
                 sample.save();
             }
-            Iterator<GsmObservationWrapper> iterator = GsmObservationWrapper.findAll(GsmObservationWrapper.class);
-            while (iterator.hasNext()){
-                GsmObservationWrapper next = iterator.next();
-                Log.d("GsmObs find all ", next.getId()+ " " +next.toString());
-            }
-
         } else if (telephonyState instanceof CdmaObservation) {
             CdmaObservationWrapper sample = this.gson.fromJson(telephonyState.toString(), CdmaObservationWrapper.class);
             sample.save();

--- a/app/src/main/java/cl/niclabs/adkintunmobile/services/monitors/TelephonyMonitor.java
+++ b/app/src/main/java/cl/niclabs/adkintunmobile/services/monitors/TelephonyMonitor.java
@@ -23,6 +23,8 @@ import cl.niclabs.adkmobile.monitor.listeners.TelephonyListener;
 
 public class TelephonyMonitor extends Service implements TelephonyListener {
 
+    private final String TAG = "AdkM:TelephonyMonitor";
+
     private static boolean running = false;
     private Monitor.Controller<TelephonyListener> phoneController;
     private Gson gson;
@@ -81,10 +83,10 @@ public class TelephonyMonitor extends Service implements TelephonyListener {
 
             if (sample.signalStrength == null)
                 sample.signalStrength = new SampleWrapper();
-            Log.d("GsmObs", "this sample: " + sample.getId()+ " "+ sample.toString() );
+            Log.d(TAG, "this sample: " + sample.getId() + " " + sample.toString() );
 
             if (lastSample != null && sample.sameAntenna(lastSample)){
-                Log.d("GsmObs", "last sample: " + lastSample.getId()+" "+lastSample.toString());
+                Log.d(TAG, "last sample: " + lastSample.getId() + " " + lastSample.toString());
 
                 if (sample.signalStrength.size > lastSample.signalStrength.size){
                     lastSample.signalStrength = sample.signalStrength;
@@ -92,7 +94,7 @@ public class TelephonyMonitor extends Service implements TelephonyListener {
                 }
                 else
                     sample.save();
-                Log.d("GsmObs", "updated sample: " + lastSample.getId() + " " + lastSample.toString());
+                Log.d(TAG, "updated sample: " + lastSample.getId() + " " + lastSample.toString());
 
             }
             else {


### PR DESCRIPTION
Se evita el almacenamiento de registros incrementales del tipo GsmObservation (#115), comparando cada nuevo registro con el último guardado, actualizando el registro ya guardado en caso de que correspondan a muestras incrementales (con igual _timestamp_) .
Además, se modifica la lógica de envío de GsmObservation's, **no** realizando el envío del último registro guardado en la base de datos, para así evitar el posible envío de registros incrementales.