### PR TITLE
close #116

### DIFF
--- a/app/src/main/java/cl/niclabs/adkintunmobile/services/monitors/TrafficMonitor.java
+++ b/app/src/main/java/cl/niclabs/adkintunmobile/services/monitors/TrafficMonitor.java
@@ -2,6 +2,7 @@ package cl.niclabs.adkintunmobile.services.monitors;
 
 import android.app.Service;
 import android.content.Intent;
+import android.os.Bundle;
 import android.os.IBinder;
 
 import com.google.gson.Gson;
@@ -53,10 +54,11 @@ public class TrafficMonitor extends Service implements TrafficListener {
         this.trafficController = Traffic.bind(Traffic.class, this);
         this.trafficController.listen(this, true);
         // set sample frequency
-        //Bundle bundle = new Bundle();
-        //bundle.putInt(Traffic.TRAFFIC_UPDATE_INTERVAL_EXTRA, 20);
+        Bundle bundle = new Bundle();
+        bundle.putInt(Traffic.TRAFFIC_UPDATE_INTERVAL_EXTRA, 20);
+        this.trafficController.activate(Monitor.TRAFFIC_APPLICATION, bundle);
         //this.trafficController.activate(Monitor.TRAFFIC_WIFI | Monitor.TRAFFIC_MOBILE | Monitor.TRAFFIC_APPLICATION, bundle);
-        this.trafficController.activate(Monitor.TRAFFIC_WIFI | Monitor.TRAFFIC_MOBILE | Monitor.TRAFFIC_APPLICATION);
+        //this.trafficController.activate(Monitor.TRAFFIC_WIFI | Monitor.TRAFFIC_MOBILE | Monitor.TRAFFIC_APPLICATION);
     }
 
     public void stopMonitor() {


### PR DESCRIPTION
Se reducen los monitores activos para recopilar sólo la información realmente útil y necesaria para las vistas. Se especifica el tiempo de muestreo cada 20 segundos