### PR TITLE
Preferencia de tipo de compresión

### DIFF
--- a/app/src/main/java/cl/niclabs/adkintunmobile/services/sync/Synchronization.java
+++ b/app/src/main/java/cl/niclabs/adkintunmobile/services/sync/Synchronization.java
@@ -3,9 +3,12 @@ package cl.niclabs.adkintunmobile.services.sync;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.IBinder;
+import android.preference.PreferenceManager;
 import android.util.Log;
 
+import cl.niclabs.adkintunmobile.R;
 import cl.niclabs.adkintunmobile.data.Report;
 import cl.niclabs.adkintunmobile.utils.compression.CompressionUtils;
 
@@ -25,12 +28,17 @@ public class Synchronization extends Service {
         this.context = this;
         Log.d(this.TAG, "Creado El servicio de sincronización");
 
-        // 1.- Build a report
+        // 1.- Build a report and get CompressionType
         Report report = new Report(getApplicationContext());
+
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+        int selectedCompressionType = Integer.parseInt(sharedPreferences.getString(getString(R.string.settings_sampling_compression_type_key), "0"));
+        CompressionUtils.CompressionType compressionType = CompressionUtils.CompressionType.getCompressionType(selectedCompressionType);
+        Log.d(TAG, "Usando compresión: " + compressionType);
 
         if (report.recordsToSend()){
             // 2.- Save report
-            report.saveFile(context, CompressionUtils.CompressionType.GZIP);
+            report.saveFile(context, compressionType);
             // 3.- Backup visualization data
             report.saveVisualSamples();
             // 4.- Clean DB

--- a/app/src/main/java/cl/niclabs/adkintunmobile/utils/compression/CompressionUtils.java
+++ b/app/src/main/java/cl/niclabs/adkintunmobile/utils/compression/CompressionUtils.java
@@ -12,7 +12,11 @@ import java.util.zip.Inflater;
 public class CompressionUtils {
 
     public enum CompressionType{
-        NOCOMPRESSION, GZIP, ZIPDEFLATER
+        NOCOMPRESSION, GZIP, ZIPDEFLATER;
+
+        public static CompressionType getCompressionType(int type){
+            return CompressionType.values()[type];
+        }
     }
 
     private static final String TAG = "AdkM:CompressionUtils";

--- a/app/src/main/java/cl/niclabs/adkintunmobile/views/settings/SettingsFragment.java
+++ b/app/src/main/java/cl/niclabs/adkintunmobile/views/settings/SettingsFragment.java
@@ -52,7 +52,12 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
 
         /* Remove preferences available only in debug mode */
         if (!BuildConfig.DEBUG_MODE) {
+            PreferenceScreen preferenceScreen = (PreferenceScreen) findPreference(getString(R.string.settings_main_screen_key));
             PreferenceCategory preferenceCategory = (PreferenceCategory) findPreference(getString(R.string.settings_sampling_category_key));
+            preferenceScreen.removePreference(preferenceCategory);
+
+            //preferenceCategory.removeAll();
+            /**
             ArrayList<Preference> debugPreferences = new ArrayList<>();
             debugPreferences.add(findPreference(getString(R.string.settings_sampling_hostname_key)));
             debugPreferences.add(findPreference(getString(R.string.settings_sampling_frequency_key)));
@@ -61,7 +66,7 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
 
             for (Preference preferenceToRemove : debugPreferences)
                 preferenceCategory.removePreference(preferenceToRemove);
-
+            **/
         }
     }
 

--- a/app/src/main/java/cl/niclabs/adkintunmobile/views/settings/SettingsFragment.java
+++ b/app/src/main/java/cl/niclabs/adkintunmobile/views/settings/SettingsFragment.java
@@ -57,6 +57,7 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
             debugPreferences.add(findPreference(getString(R.string.settings_sampling_hostname_key)));
             debugPreferences.add(findPreference(getString(R.string.settings_sampling_frequency_key)));
             debugPreferences.add(findPreference(getString(R.string.settings_sampling_startsync_key)));
+            debugPreferences.add(findPreference(getString(R.string.settings_sampling_compression_type_key)));
 
             for (Preference preferenceToRemove : debugPreferences)
                 preferenceCategory.removePreference(preferenceToRemove);

--- a/app/src/main/java/cl/niclabs/adkintunmobile/views/settings/SettingsFragment.java
+++ b/app/src/main/java/cl/niclabs/adkintunmobile/views/settings/SettingsFragment.java
@@ -55,18 +55,6 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
             PreferenceScreen preferenceScreen = (PreferenceScreen) findPreference(getString(R.string.settings_main_screen_key));
             PreferenceCategory preferenceCategory = (PreferenceCategory) findPreference(getString(R.string.settings_sampling_category_key));
             preferenceScreen.removePreference(preferenceCategory);
-
-            //preferenceCategory.removeAll();
-            /**
-            ArrayList<Preference> debugPreferences = new ArrayList<>();
-            debugPreferences.add(findPreference(getString(R.string.settings_sampling_hostname_key)));
-            debugPreferences.add(findPreference(getString(R.string.settings_sampling_frequency_key)));
-            debugPreferences.add(findPreference(getString(R.string.settings_sampling_startsync_key)));
-            debugPreferences.add(findPreference(getString(R.string.settings_sampling_compression_type_key)));
-
-            for (Preference preferenceToRemove : debugPreferences)
-                preferenceCategory.removePreference(preferenceToRemove);
-            **/
         }
     }
 

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -19,12 +19,12 @@
     <string-array name="sync_sampling_compression_type">
         <item>Sin Compresión</item>
         <item>Compresión GZip</item>
-        <item>Compresión ZipDeflater</item>
+        <!-- <item>Compresión ZipDeflater</item> -->
     </string-array>
     <string-array name="sync_sampling_compression_type_values">
         <item>0</item>
         <item>1</item>
-        <item>2</item>
+        <!-- <item>2</item> -->
     </string-array>
 
     <!-- Doughnut Chart -->

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Preferences -->
     <string-array name="sync_sampling_frequency">
         <item>Cada 1 Minuto</item>
         <item>Cada 2 Minutos</item>
@@ -13,6 +14,17 @@
         <item>5</item>
         <item>10</item>
         <item>30</item>
+    </string-array>
+
+    <string-array name="sync_sampling_compression_type">
+        <item>Sin Compresión</item>
+        <item>Compresión GZip</item>
+        <item>Compresión ZipDeflater</item>
+    </string-array>
+    <string-array name="sync_sampling_compression_type_values">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
     </string-array>
 
     <!-- Doughnut Chart -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <!-- Preferences Strings -->
     <string name="settings_updated">Preferencias actualizadas</string>
 
+    <string name="settings_main_screen_key">settings_main</string>
     <string name="settings_app_data_category">Ajustes de la aplicación</string>
     <string name="settings_app_data_quota_total_key">plan_data_quota</string>
     <string name="settings_app_data_quota_total_title">Cuota de navegación de tu plan de datos</string>
@@ -31,7 +32,7 @@
     <string name="settings_app_data_clean_ip_location_cache_summary">Elimina los datos descargados para desplegar el mapa de conexiones activas.</string>
     <string name="settings_app_data_clean_ip_location_cache_message">Datos temporales borrados</string>
 
-    <string name="settings_sampling_category">Ajustes de sincronización</string>
+    <string name="settings_sampling_category">Opciones de Debug</string>
     <string name="settings_sampling_category_key">sync_category_key</string>
     <string name="settings_sampling_hostname_key">sync_hostname</string>
     <string name="settings_sampling_hostname_title">Dirección del servidor</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,9 @@
     <string name="settings_sampling_startsync_title">Gatillar Sincronización</string>
     <string name="settings_sampling_lastsync_key">sync_lastsync</string>
     <string name="settings_sampling_lastsync_title">Última Sincronización</string>
+    <string name="settings_sampling_compression_type_key">sync_compression_type</string>
+    <string name="settings_sampling_compression_type_title">Tipo de compresión utilizada</string>
+
 
     <string name="settings_app_category">Aplicación</string>
     <string name="settings_app_version_key">app_version</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -46,6 +46,15 @@
             android:key="@string/settings_sampling_startsync_key"
             android:title="@string/settings_sampling_startsync_title"
             />
+        <ListPreference
+            android:key="@string/settings_sampling_compression_type_key"
+            android:title="@string/settings_sampling_compression_type_title"
+            android:dialogTitle="@string/settings_sampling_compression_type_title"
+            android:defaultValue="1"
+            android:summary="%s"
+            android:entries="@array/sync_sampling_compression_type"
+            android:entryValues="@array/sync_sampling_compression_type_values"
+            />
     </PreferenceCategory>
     <PreferenceCategory
         android:title="@string/settings_app_category"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    android:key="@string/settings_main_screen_key">
 
     <PreferenceCategory
         android:title="@string/settings_app_data_category"
@@ -39,10 +40,6 @@
             android:entryValues="@array/sync_sampling_frequency_values"
             />
         <Preference
-            android:key="@string/settings_sampling_lastsync_key"
-            android:title="@string/settings_sampling_lastsync_title"
-            />
-        <Preference
             android:key="@string/settings_sampling_startsync_key"
             android:title="@string/settings_sampling_startsync_title"
             />
@@ -59,6 +56,10 @@
     <PreferenceCategory
         android:title="@string/settings_app_category"
         >
+        <Preference
+            android:key="@string/settings_sampling_lastsync_key"
+            android:title="@string/settings_sampling_lastsync_title"
+            />
         <Preference
             android:key="@string/settings_app_version_key"
             android:title="@string/settings_app_version_title"


### PR DESCRIPTION
Se añade a las preferencias del modo DEBUG la selección del tipo de compresión a utilizar en el envío de reportes. Las opciones disponibles están relacionadas al EnumType "CompressionType" de la clase CompressionUtils. Al realizarse la sincronización, se toma desde las preferencias la compresión seleccionada, siendo la compresión "GZip" la por defecto.